### PR TITLE
Try in editor

### DIFF
--- a/src/EditorLayout.tsx
+++ b/src/EditorLayout.tsx
@@ -1,5 +1,4 @@
-import React, { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { FC, memo, ReactNode, ChangeEvent } from 'react';
 import DownloadButton from './reusable/DownloadButton';
 import UploadButton from './reusable/UploadButton';
 
@@ -7,13 +6,15 @@ interface EditorLayoutProps {
   children: ReactNode;
   toolIcon?: string; // Path to the SVG icon
   onDownload?: () => void;
-  onUpload: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  goToEditor?: () => void;
+  onUpload: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
-const EditorLayout: React.FC<EditorLayoutProps> = ({
+const EditorLayout: FC<EditorLayoutProps> = ({
   children,
   onDownload,
-  onUpload
+  onUpload,
+  goToEditor
 }) => {
   return (
     <div className="flex flex-col items-center justify-center gap-3 min-h-screen bg-gray-50">
@@ -27,14 +28,18 @@ const EditorLayout: React.FC<EditorLayoutProps> = ({
             <UploadButton onUpload={onUpload} />
             <DownloadButton downloadAction={onDownload} />
           </div>
-
-          <Link to="/" className="flex items-center justify-center py-2 border px-[5%] rounded-lg border-purple-600 bg-purple-600 hover:bg-purple-700">
-            <h6 className="text-base font-sans font-medium text-white">Try In Editor</h6>
-          </Link>
+          <div>
+            <button
+              className="flex items-center justify-center py-2 border px-[5%] rounded-lg border-purple-600 bg-purple-600 hover:bg-purple-700"
+              onClick={goToEditor}
+            >
+              <span className="text-base font-medium font-sans">Try In Editor</span>
+            </button>
+          </div>
         </div>
       </div>
     </div>
   );
 };
 
-export default EditorLayout;
+export default memo(EditorLayout);

--- a/src/hooks/useHandleFile.ts
+++ b/src/hooks/useHandleFile.ts
@@ -52,7 +52,25 @@ const useHandleFile = (originalCanvasRef: React.RefObject<HTMLCanvasElement | nu
         document.body.removeChild(link);
     };
 
-    return { image, handleUpload, handleDownload };
+    const goToEditor = () => {
+      if (!originalCanvasRef.current) return;
+      originalCanvasRef.current.toBlob(blob => {
+        if (!blob) {
+          console.error('Canvas toBlob failed');
+          return;
+        }
+      
+        const blobUrl = URL.createObjectURL(blob);
+        const encoded = encodeURIComponent(blobUrl);
+        const editorUrl = `https://editor.vertex.art/data=${encoded}`;
+      
+        window.open(editorUrl, '_blank');
+      });
+      
+  };
+
+
+    return { image, handleUpload, handleDownload, goToEditor };
 };
 
 export default useHandleFile;

--- a/src/reusable/DownloadButton.tsx
+++ b/src/reusable/DownloadButton.tsx
@@ -1,11 +1,11 @@
-import React from "react";
+import  { FC, memo } from "react";
 
 interface DownloadButtonProps {
   downloadAction?: () => void;
   disabled?: boolean;
 }
 
-const DownloadButton: React.FC<DownloadButtonProps> = ({
+const DownloadButton: FC<DownloadButtonProps> = ({
   downloadAction,
   disabled = false
 }) => {
@@ -21,4 +21,4 @@ const DownloadButton: React.FC<DownloadButtonProps> = ({
   );
 };
 
-export default DownloadButton;
+export default memo(DownloadButton);

--- a/src/tools/brightness/index.tsx
+++ b/src/tools/brightness/index.tsx
@@ -9,11 +9,9 @@ import { adjustBrightness } from "./adjustBrightness";
 const Brightness = () => {
   // Canvas for download operations (hidden)
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  // Canvas for preview (visible to user)
   const previewCanvasRef = useRef<HTMLCanvasElement | null>(null);
   
-  // Use the hook for image handling
-  const { image, handleUpload, handleDownload: originalHandleDownload } = useHandleFile(canvasRef);
+  const { image, handleUpload, handleDownload: originalHandleDownload, goToEditor } = useHandleFile(canvasRef);
 
   useIframeResize()
   
@@ -89,6 +87,7 @@ const Brightness = () => {
       toolIcon="assets/brightness-contrast.svg"
       onDownload={image ? handleDownload : undefined}
       onUpload={handleUpload}
+      goToEditor={goToEditor}
     >
       {/* Hidden canvas used by useHandleFile hook for export */}
       <canvas ref={canvasRef} className="hidden" />

--- a/src/tools/colorBalance/index.tsx
+++ b/src/tools/colorBalance/index.tsx
@@ -13,7 +13,7 @@ const ColorBalance = () => {
   const previewCanvasRef = useRef<HTMLCanvasElement | null>(null);
   
   // Use the hook for image handling
-  const { image, handleUpload, handleDownload: originalHandleDownload } = useHandleFile(canvasRef);
+  const { image, handleUpload, handleDownload: originalHandleDownload, goToEditor } = useHandleFile(canvasRef);
 
   useIframeResize()
   
@@ -99,6 +99,7 @@ const ColorBalance = () => {
       toolIcon="assets/color-balance.svg"
       onDownload={image ? handleDownload : undefined}
       onUpload={handleUpload}
+      goToEditor={goToEditor}
     >
       {/* Hidden canvas used by useHandleFile hook for export */}
       <canvas ref={canvasRef} className="hidden" />

--- a/src/tools/colorPalette/ColorPalette.tsx
+++ b/src/tools/colorPalette/ColorPalette.tsx
@@ -8,7 +8,7 @@ import useIframeResize from "../../hooks/useIframeResize";
 
 const ColorPalette = () => {
     const originalCanvasRef = useRef<HTMLCanvasElement | null>(null);
-    const { image, handleUpload, handleDownload } = useHandleFile(originalCanvasRef);
+    const { image, handleUpload, handleDownload, goToEditor } = useHandleFile(originalCanvasRef);
     useIframeResize()
 
     return (
@@ -16,6 +16,7 @@ const ColorPalette = () => {
             toolIcon="assets/flip-horizontal.svg"
             onDownload={image ? handleDownload : undefined}
             onUpload={handleUpload}
+            goToEditor={goToEditor}
         >
             {!image ? (
                 <DragAndDrop onUploadAction={handleUpload} />

--- a/src/tools/filters/Filters.tsx
+++ b/src/tools/filters/Filters.tsx
@@ -12,7 +12,7 @@ import { drawScaledImage } from "../../reusable/drawScaledImage";
 const Filters = () => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const previewCanvasRef = useRef<HTMLCanvasElement | null>(null);
-  const { image, handleUpload, handleDownload: originalHandleDownload } = useHandleFile(canvasRef, previewCanvasRef, 600);
+  const { image, handleUpload, handleDownload: originalHandleDownload, goToEditor } = useHandleFile(canvasRef, previewCanvasRef, 600);
 
   useIframeResize()
 
@@ -76,6 +76,7 @@ const Filters = () => {
       toolIcon="assets/filters.svg"
       onDownload={image ? handleDownload : undefined}
       onUpload={handleUpload}
+      goToEditor={goToEditor}
     >
       <div
         style={{ width: previewCanvasRef.current?.width, height: previewCanvasRef.current?.height }}

--- a/src/tools/flip/Flip.tsx
+++ b/src/tools/flip/Flip.tsx
@@ -9,7 +9,7 @@ import useIframeResize from "../../hooks/useIframeResize";
 const Flip = ({ maxCanvasSize }: { maxCanvasSize?: number }) => {
   const originalCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const previewCanvasRef = useRef<HTMLCanvasElement | null>(null);
-  const { image, handleUpload, handleDownload } = useHandleFile(originalCanvasRef, previewCanvasRef, maxCanvasSize);
+  const { image, handleUpload, handleDownload, goToEditor } = useHandleFile(originalCanvasRef, previewCanvasRef, maxCanvasSize);
 
   useIframeResize()
 
@@ -42,6 +42,7 @@ const Flip = ({ maxCanvasSize }: { maxCanvasSize?: number }) => {
       toolIcon="assets/flip-horizontal.svg"
       onDownload={image ? handleDownload : undefined}
       onUpload={handleUpload}
+      goToEditor={goToEditor}
     >
       {!image ? (
         <DragAndDrop onUploadAction={handleUpload} />

--- a/src/tools/glitch/index.tsx
+++ b/src/tools/glitch/index.tsx
@@ -13,7 +13,7 @@ const Glitch = () => {
   const previewCanvasRef = useRef<HTMLCanvasElement | null>(null);
   
   // Use the hook for image handling
-  const { image, handleUpload, handleDownload: originalHandleDownload } = useHandleFile(canvasRef);
+  const { image, handleUpload, handleDownload: originalHandleDownload, goToEditor } = useHandleFile(canvasRef);
   useIframeResize()
   
   // Store adjustment values in refs to avoid rerenders
@@ -140,6 +140,7 @@ const Glitch = () => {
       toolIcon="assets/glitch.svg"
       onDownload={image ? handleDownload : undefined}
       onUpload={handleUpload}
+      goToEditor={goToEditor}
     >
       {/* Hidden canvas used by useHandleFile hook for export */}
       <canvas ref={canvasRef} className="hidden" />

--- a/src/tools/grayscale/Grayscale.tsx
+++ b/src/tools/grayscale/Grayscale.tsx
@@ -9,7 +9,7 @@ import EditorLayout from "../../EditorLayout";
 
 const Grayscale = () => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const { image, handleUpload, handleDownload } = useHandleFile(canvasRef);
+  const { image, handleUpload, handleDownload, goToEditor } = useHandleFile(canvasRef);
 
   useIframeResize()
 
@@ -20,6 +20,7 @@ const Grayscale = () => {
       toolIcon="assets/grayscale.svg"
       onDownload={image ? handleDownload : undefined}
       onUpload={handleUpload}
+      goToEditor={goToEditor}
     >
       <canvas ref={canvasRef} className="hidden" />
       

--- a/src/tools/pixelize/Pixelize.tsx
+++ b/src/tools/pixelize/Pixelize.tsx
@@ -10,7 +10,7 @@ const Pixelize = () => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const previewCanvasRef = useRef<HTMLCanvasElement | null>(null);
 
-  const { image, handleUpload, handleDownload } = useHandleFile(canvasRef, previewCanvasRef, 600);
+  const { image, handleUpload, handleDownload, goToEditor } = useHandleFile(canvasRef, previewCanvasRef, 600);
 
   useIframeResize()
 
@@ -23,6 +23,7 @@ const Pixelize = () => {
       toolIcon="assets/pixelize.svg"
       onDownload={image ? handleDownload : undefined}
       onUpload={handleUpload}
+      goToEditor={goToEditor}
     >
       <canvas ref={canvasRef} className="hidden" />
       <canvas ref={previewCanvasRef} className="hidden" />

--- a/src/tools/text/index.tsx
+++ b/src/tools/text/index.tsx
@@ -20,7 +20,7 @@ const Text = () => {
   const previewCanvasRef = useRef<HTMLCanvasElement | null>(null);
   
   // Use the hook for image handling
-  const { image, handleUpload, handleDownload: originalHandleDownload } = useHandleFile(canvasRef);
+  const { image, handleUpload, handleDownload: originalHandleDownload, goToEditor } = useHandleFile(canvasRef);
 
   useIframeResize()
   
@@ -143,6 +143,7 @@ const Text = () => {
       toolIcon="assets/text.svg"
       onDownload={image ? handleDownload : undefined}
       onUpload={handleUpload}
+      goToEditor={goToEditor}
     >
       {/* Hidden canvas used by useHandleFile hook for export */}
       <canvas ref={canvasRef} className="hidden" />

--- a/src/tools/watermark/index.tsx
+++ b/src/tools/watermark/index.tsx
@@ -23,7 +23,7 @@ const Watermark = () => {
   const previewCanvasRef = useRef<HTMLCanvasElement | null>(null);
   
   // Use the hook for image handling
-  const { image, handleUpload, handleDownload: originalHandleDownload } = useHandleFile(canvasRef, previewCanvasRef);
+  const { image, handleUpload, handleDownload: originalHandleDownload, goToEditor } = useHandleFile(canvasRef, previewCanvasRef);
   
   useIframeResize()
   
@@ -210,6 +210,7 @@ const Watermark = () => {
       toolIcon="assets/watermark.svg"
       onDownload={image ? handleDownload : undefined}
       onUpload={handleUpload}
+      goToEditor={goToEditor}
     >
       <canvas ref={canvasRef} className="hidden" />
 


### PR DESCRIPTION
…nctionality

- Updated EditorLayout to accept a new goToEditor prop and replaced Link with a button for navigation.
- Enhanced useHandleFile hook to include goToEditor method for generating editor URLs.
- Integrated goToEditor in various tools (Brightness, ColorBalance, ColorPalette, Filters, Flip, Glitch, Grayscale, Pixelize, Text, Watermark) to enable navigation to the editor with the current canvas data.
- Refactored DownloadButton and EditorLayout to use memo for performance optimization.